### PR TITLE
Ensure that small letters in MSA are also replaced with small letters

### DIFF
--- a/SPEACH_AF_scan.ipynb
+++ b/SPEACH_AF_scan.ipynb
@@ -153,8 +153,10 @@
     "    res_c = np.array(res_use[p])\n",
     "    no_res = len(res_c)\n",
     "    change_to = ''\n",
+    "    change_to_lower=''#ensure that lower case letters in MSA are also replaced with lower case letters\n",
     "    for m in range(0,no_res):\n",
     "        change_to += 'A'\n",
+    "        change_to_lower +='a'\n",
     "    alidatac = copy.deepcopy(records)\n",
     "    nos = len(alidatac);\n",
     "    los = len(alidatac[0].seq);\n",
@@ -173,7 +175,10 @@
     "            if np.isin(count,res_c):\n",
     "                inds = np.where(res_c == count)[0][0]\n",
     "                if temp[n] != '-':\n",
-    "                    temp = temp[:n] + change_to[inds] + temp[n+1:]\n",
+    "                    if temp[n].islower():\n",
+    "                        temp=temp[:n]+change_to_lower[inds]+temp[n+1:]\n",
+    "                    else:\n",
+    "                        temp = temp[:n] + change_to[inds] + temp[n+1:]                    \n",
     "        alidatac[m].seq = Seq(temp);\n",
     "\n",
     "        lines.append('>'+alidatac[m].description+'\\n')\n",
@@ -212,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I recently encountered an issue when combining SPEACH_AF with openfold.
There is a problem with the format of the deletion matrix in openfold if small letters in the MSA are replaced with captial "A"s. I've made a few changes to the original scan script that fixes this.

If you don't want to incorporate this, feel free to discard this pull request. 